### PR TITLE
Cpython bdw nogc

### DIFF
--- a/Doc/c-api/refcounting.rst
+++ b/Doc/c-api/refcounting.rst
@@ -68,6 +68,6 @@ simply exported function versions of :c:func:`Py_XINCREF` and
 :c:func:`Py_XDECREF`, respectively.
 
 The following functions or macros are only for use within the interpreter core:
-:c:func:`_Py_Dealloc`, :c:func:`_Py_ForgetReference`, :c:func:`_Py_NewReference`,
+:c:func:`_Py_ForgetReference`, :c:func:`_Py_NewReference`,
 as well as the global variable :c:data:`_Py_RefTotal`.
 

--- a/Include/Python.h
+++ b/Include/Python.h
@@ -60,6 +60,13 @@
  */
 #include <assert.h>
 
+/* libgc doesn't appear to have a config.h for these defines, so assume
+ * GC_THREADS support is enabled.
+ */
+#define GC_THREADS 1
+/* Include gc.h for its intercepts of thread functions. */
+#include <gc/gc.h>
+
 #include "pyport.h"
 #include "pymacro.h"
 

--- a/Include/Python.h
+++ b/Include/Python.h
@@ -64,6 +64,7 @@
  * GC_THREADS support is enabled.
  */
 #define GC_THREADS 1
+/* #define GC_DEBUG 1 */
 /* Include gc.h for its intercepts of thread functions. */
 #include <gc/gc.h>
 

--- a/Include/cpython/object.h
+++ b/Include/cpython/object.h
@@ -332,18 +332,6 @@ _PyObject_GenericSetAttrWithDict(PyObject *, PyObject *,
 
 #define PyType_HasFeature(t,f)  (((t)->tp_flags & (f)) != 0)
 
-static inline void _Py_Dealloc_inline(PyObject *op)
-{
-    destructor dealloc = Py_TYPE(op)->tp_dealloc;
-#ifdef Py_TRACE_REFS
-    _Py_ForgetReference(op);
-#else
-    _Py_INC_TPFREES(op);
-#endif
-    (*dealloc)(op);
-}
-#define _Py_Dealloc(op) _Py_Dealloc_inline(op)
-
 
 /* Safely decref `op` and set `op` to `op2`.
  *

--- a/Include/cpython/objimpl.h
+++ b/Include/cpython/objimpl.h
@@ -38,9 +38,7 @@ PyAPI_FUNC(Py_ssize_t) _PyGC_CollectIfEnabled(void);
 
 
 /* Test if an object has a GC head */
-#define PyObject_IS_GC(o) \
-    (PyType_IS_GC(Py_TYPE(o)) \
-     && (Py_TYPE(o)->tp_is_gc == NULL || Py_TYPE(o)->tp_is_gc(o)))
+#define PyObject_IS_GC(o) (0)
 
 /* GC information is stored BEFORE the object structure. */
 typedef struct {
@@ -57,7 +55,7 @@ typedef struct {
 #define _Py_FROM_GC(o) ((PyObject *)((PyGC_Head *)(o)+1))
 
 /* True if the object is currently tracked by the GC. */
-#define _PyObject_GC_IS_TRACKED(o) (_Py_AS_GC(o)->_gc_next != 0)
+#define _PyObject_GC_IS_TRACKED(o) (0)
 
 /* True if the object may be tracked by the GC in the future, or already is.
    This can be useful to implement some optimizations. */

--- a/Include/cpython/objimpl.h
+++ b/Include/cpython/objimpl.h
@@ -54,6 +54,7 @@ typedef struct {
 } PyGC_Head;
 
 #define _Py_AS_GC(o) ((PyGC_Head *)(o)-1)
+#define _Py_FROM_GC(o) ((PyObject *)((PyGC_Head *)(o)+1))
 
 /* True if the object is currently tracked by the GC. */
 #define _PyObject_GC_IS_TRACKED(o) (_Py_AS_GC(o)->_gc_next != 0)

--- a/Include/internal/pycore_object.h
+++ b/Include/internal/pycore_object.h
@@ -28,21 +28,7 @@ PyAPI_FUNC(int) _PyDict_CheckConsistency(PyObject *mp, int check_content);
 static inline void _PyObject_GC_TRACK_impl(const char *filename, int lineno,
                                            PyObject *op)
 {
-    _PyObject_ASSERT_FROM(op, !_PyObject_GC_IS_TRACKED(op),
-                          "object already tracked by the garbage collector",
-                          filename, lineno, "_PyObject_GC_TRACK");
-
-    PyGC_Head *gc = _Py_AS_GC(op);
-    _PyObject_ASSERT_FROM(op,
-                          (gc->_gc_prev & _PyGC_PREV_MASK_COLLECTING) == 0,
-                          "object is in generation which is garbage collected",
-                          filename, lineno, "_PyObject_GC_TRACK");
-
-    PyGC_Head *last = (PyGC_Head*)(_PyRuntime.gc.generation0->_gc_prev);
-    _PyGCHead_SET_NEXT(last, gc);
-    _PyGCHead_SET_PREV(gc, last);
-    _PyGCHead_SET_NEXT(gc, _PyRuntime.gc.generation0);
-    _PyRuntime.gc.generation0->_gc_prev = (uintptr_t)gc;
+    return;
 }
 
 #define _PyObject_GC_TRACK(op) \
@@ -60,17 +46,7 @@ static inline void _PyObject_GC_TRACK_impl(const char *filename, int lineno,
 static inline void _PyObject_GC_UNTRACK_impl(const char *filename, int lineno,
                                              PyObject *op)
 {
-    _PyObject_ASSERT_FROM(op, _PyObject_GC_IS_TRACKED(op),
-                          "object not tracked by the garbage collector",
-                          filename, lineno, "_PyObject_GC_UNTRACK");
-
-    PyGC_Head *gc = _Py_AS_GC(op);
-    PyGC_Head *prev = _PyGCHead_PREV(gc);
-    PyGC_Head *next = _PyGCHead_NEXT(gc);
-    _PyGCHead_SET_NEXT(prev, next);
-    _PyGCHead_SET_PREV(next, prev);
-    gc->_gc_next = 0;
-    gc->_gc_prev &= _PyGC_PREV_MASK_FINALIZED;
+    return;
 }
 
 #define _PyObject_GC_UNTRACK(op) \

--- a/Include/object.h
+++ b/Include/object.h
@@ -441,7 +441,6 @@ static inline void _Py_ForgetReference(PyObject *op)
 #endif /* !Py_TRACE_REFS */
 
 
-PyAPI_FUNC(void) _Py_Dealloc(PyObject *);
 PyAPI_FUNC(void) _Py_Dealloc_finalizer(void *, void *);
 PyAPI_FUNC(void) _Py_Dealloc_GC_finalizer(void *, void *);
 
@@ -465,9 +464,6 @@ static inline void _Py_DECREF(const char *filename, int lineno,
             _Py_NegativeRefcount(filename, lineno, op);
         }
 #endif
-    }
-    else {
-        _Py_Dealloc(op);
     }
 }
 

--- a/Include/object.h
+++ b/Include/object.h
@@ -442,6 +442,8 @@ static inline void _Py_ForgetReference(PyObject *op)
 
 
 PyAPI_FUNC(void) _Py_Dealloc(PyObject *);
+PyAPI_FUNC(void) _Py_Dealloc_finalizer(void *, void *);
+PyAPI_FUNC(void) _Py_Dealloc_GC_finalizer(void *, void *);
 
 static inline void _Py_INCREF(PyObject *op)
 {

--- a/Include/objimpl.h
+++ b/Include/objimpl.h
@@ -119,7 +119,7 @@ PyAPI_FUNC(void) PyObject_Free(void *ptr);
 PyAPI_FUNC(Py_ssize_t) PyGC_Collect(void);
 
 /* Test if a type has a GC head */
-#define PyType_IS_GC(t) PyType_HasFeature((t), Py_TPFLAGS_HAVE_GC)
+#define PyType_IS_GC(t) (0)
 
 PyAPI_FUNC(PyVarObject *) _PyObject_GC_Resize(PyVarObject *, Py_ssize_t);
 #define PyObject_GC_Resize(type, op, n) \
@@ -201,11 +201,7 @@ _PyObject_INIT(PyObject *op, PyTypeObject *typeobj)
     }
     _Py_NewReference(op);
     if (GC_is_heap_ptr(op)) {
-        if (PyType_IS_GC(typeobj)) {
-            GC_REGISTER_FINALIZER(_Py_AS_GC(op), _Py_Dealloc_GC_finalizer, NULL, NULL, NULL);
-        } else {
-            GC_REGISTER_FINALIZER(op, _Py_Dealloc_finalizer, NULL, NULL, NULL);
-        }
+        GC_REGISTER_FINALIZER_IGNORE_SELF(op, _Py_Dealloc_finalizer, NULL, NULL, NULL);
     }
     return op;
 }

--- a/Lib/test/test_capi.py
+++ b/Lib/test/test_capi.py
@@ -540,12 +540,15 @@ class PyMemDebugTests(unittest.TestCase):
         code = code.format(func=func)
         assert_python_ok('-c', code, PYTHONMALLOC=self.PYTHONMALLOC)
 
+    @unittest.skipUnless(support.with_pymalloc(), 'need pymalloc')
     def test_pyobject_is_freed_uninitialized(self):
         self.check_pyobject_is_freed('pyobject_uninitialized')
 
+    @unittest.skipUnless(support.with_pymalloc(), 'need pymalloc')
     def test_pyobject_is_freed_forbidden_bytes(self):
         self.check_pyobject_is_freed('pyobject_forbidden_bytes')
 
+    @unittest.skipUnless(support.with_pymalloc(), 'need pymalloc')
     def test_pyobject_is_freed_free(self):
         self.check_pyobject_is_freed('pyobject_freed')
 

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -231,7 +231,8 @@ INSTSONAME=	@INSTSONAME@
 LIBS=		@LIBS@
 LIBM=		@LIBM@
 LIBC=		@LIBC@
-SYSLIBS=	$(LIBM) $(LIBC)
+LIBGC=          @LIBGC@
+SYSLIBS=	$(LIBM) $(LIBC) $(LIBGC)
 SHLIBS=		@SHLIBS@
 
 DLINCLDIR=	@DLINCLDIR@
@@ -560,7 +561,7 @@ clinic: check-clean-src $(srcdir)/Modules/_blake2/blake2s_impl.c
 
 # Build the interpreter
 $(BUILDPYTHON):	Programs/python.o $(LIBRARY) $(LDLIBRARY) $(PY3LIBRARY)
-	$(LINKCC) $(PY_CORE_LDFLAGS) $(LINKFORSHARED) -o $@ Programs/python.o $(BLDLIBRARY) $(LIBS) $(MODLIBS) $(SYSLIBS)
+	$(LINKCC) $(PY_CORE_LDFLAGS) $(LINKFORSHARED) -o $@ Programs/python.o $(BLDLIBRARY) $(LIBS) $(MODLIBS) $(SYSLIBS) $(LIBGC)
 
 platform: $(BUILDPYTHON) pybuilddir.txt
 	$(RUNSHARED) $(PYTHON_FOR_BUILD) -c 'import sys ; from sysconfig import get_platform ; print("%s-%d.%d" % (get_platform(), *sys.version_info[:2]))' >platform
@@ -615,21 +616,21 @@ $(LIBRARY): $(LIBRARY_OBJS)
 
 libpython$(LDVERSION).so: $(LIBRARY_OBJS) $(DTRACE_OBJS)
 	if test $(INSTSONAME) != $(LDLIBRARY); then \
-		$(BLDSHARED) -Wl,-h$(INSTSONAME) -o $(INSTSONAME) $(LIBRARY_OBJS) $(MODLIBS) $(SHLIBS) $(LIBC) $(LIBM); \
+		$(BLDSHARED) -Wl,-h$(INSTSONAME) -o $(INSTSONAME) $(LIBRARY_OBJS) $(MODLIBS) $(SHLIBS) $(LIBGC) $(LIBC) $(LIBM); \
 		$(LN) -f $(INSTSONAME) $@; \
 	else \
-		$(BLDSHARED) -o $@ $(LIBRARY_OBJS) $(MODLIBS) $(SHLIBS) $(LIBC) $(LIBM); \
+		$(BLDSHARED) -o $@ $(LIBRARY_OBJS) $(MODLIBS) $(SHLIBS) $(LIBGC) $(LIBC) $(LIBM); \
 	fi
 
 libpython3.so:	libpython$(LDVERSION).so
 	$(BLDSHARED) $(NO_AS_NEEDED) -o $@ -Wl,-h$@ $^
 
 libpython$(LDVERSION).dylib: $(LIBRARY_OBJS)
-	 $(CC) -dynamiclib -Wl,-single_module $(PY_CORE_LDFLAGS) -undefined dynamic_lookup -Wl,-install_name,$(prefix)/lib/libpython$(LDVERSION).dylib -Wl,-compatibility_version,$(VERSION) -Wl,-current_version,$(VERSION) -o $@ $(LIBRARY_OBJS) $(DTRACE_OBJS) $(SHLIBS) $(LIBC) $(LIBM); \
+	 $(CC) -dynamiclib -Wl,-single_module $(PY_CORE_LDFLAGS) -undefined dynamic_lookup -Wl,-install_name,$(prefix)/lib/libpython$(LDVERSION).dylib -Wl,-compatibility_version,$(VERSION) -Wl,-current_version,$(VERSION) -o $@ $(LIBRARY_OBJS) $(DTRACE_OBJS) $(SHLIBS) $(LIBGC) $(LIBC) $(LIBM); \
 
 
 libpython$(VERSION).sl: $(LIBRARY_OBJS)
-	$(LDSHARED) -o $@ $(LIBRARY_OBJS) $(MODLIBS) $(SHLIBS) $(LIBC) $(LIBM)
+	$(LDSHARED) -o $@ $(LIBRARY_OBJS) $(MODLIBS) $(SHLIBS) $(LIBGC) $(LIBC) $(LIBM)
 
 # Copy up the gdb python hooks into a position where they can be automatically
 # loaded by gdb during Lib/test/test_gdb.py

--- a/Modules/_tracemalloc.c
+++ b/Modules/_tracemalloc.c
@@ -273,13 +273,13 @@ hashtable_new(size_t key_size, size_t data_size,
 static void*
 raw_malloc(size_t size)
 {
-    return allocators.raw.malloc(allocators.raw.ctx, size);
+    return malloc(size);
 }
 
 static void
 raw_free(void *ptr)
 {
-    allocators.raw.free(allocators.raw.ctx, ptr);
+    free(ptr);
 }
 
 

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -407,11 +407,16 @@ PyOS_BeforeFork(void)
     run_at_forkers(_PyInterpreterState_Get()->before_forkers, 1);
 
     _PyImport_AcquireLock();
+    /* GC atfork_prepare needs to be called last, as it disables GC. */
+    GC_atfork_prepare();
 }
 
 void
 PyOS_AfterFork_Parent(void)
 {
+    /* GC atfork functions need to be called first, before allocations can
+     * happen. */
+    GC_atfork_parent();
     if (_PyImport_ReleaseLock() <= 0)
         Py_FatalError("failed releasing import lock after fork");
 
@@ -422,6 +427,9 @@ void
 PyOS_AfterFork_Child(void)
 {
     _PyRuntimeState *runtime = &_PyRuntime;
+    /* GC atfork functions need to be called first, before allocations can
+     * happen. */
+    GC_atfork_child();
     _PyGILState_Reinit(runtime);
     _PyInterpreterState_DeleteExceptMain(runtime);
     PyEval_ReInitThreads();

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -2213,7 +2213,7 @@ void
 _Py_Dealloc_finalizer(void *_op, void *is_gc)
 {
     PyObject *op = (PyObject *)_op;
-    assert(is_gc == NULL ? !_Py_IS_GC(op) || _Py_IS_GC(op));
+    assert(is_gc == NULL ? !PyObject_IS_GC(op) : PyObject_IS_GC(op));
     if (op->ob_refcnt != 0) {
         fprintf(stderr, "object %p refcount leak (%ld)\n", op, op->ob_refcnt);
         abort();

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -312,10 +312,10 @@ PyObject_CallFinalizerFromDealloc(PyObject *self)
     Py_ssize_t refcnt;
 
     /* Temporarily resurrect the object. */
-    if (self->ob_refcnt != 0) {
+/*    if (self->ob_refcnt != 0) {
         Py_FatalError("PyObject_CallFinalizerFromDealloc called on "
                       "object with a non-zero refcount");
-    }
+    } */
     self->ob_refcnt = 1;
 
     PyObject_CallFinalizer(self);
@@ -2213,7 +2213,7 @@ _Py_Dealloc_finalizer(void *_op, void *is_gc)
     PyObject *op = (PyObject *)_op;
     assert(is_gc == NULL ? !PyObject_IS_GC(op) : PyObject_IS_GC(op));
     if (op->ob_refcnt != 0) {
-        fprintf(stderr, "object %p refcount leak (%ld)\n", op, op->ob_refcnt);
+        // fprintf(stderr, "object %p refcount leak (%ld)\n", op, op->ob_refcnt);
     }
     _GC_Py_Dealloc(op);
 }

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -2187,10 +2187,8 @@ _PyObject_AssertFailed(PyObject *obj, const char *expr, const char *msg,
 }
 
 
-#undef _Py_Dealloc
-
 void
-_Py_Dealloc(PyObject *op)
+_GC_Py_Dealloc(PyObject *op)
 {
     destructor dealloc = Py_TYPE(op)->tp_dealloc;
 #ifdef Py_TRACE_REFS
@@ -2216,12 +2214,8 @@ _Py_Dealloc_finalizer(void *_op, void *is_gc)
     assert(is_gc == NULL ? !PyObject_IS_GC(op) : PyObject_IS_GC(op));
     if (op->ob_refcnt != 0) {
         fprintf(stderr, "object %p refcount leak (%ld)\n", op, op->ob_refcnt);
-        abort();
-    } else {
-        fprintf(stderr, "object %p not freed (refcount 0)\n", op);
-        abort();
     }
-    _Py_Dealloc(op);
+    _GC_Py_Dealloc(op);
 }
 
 #ifdef __cplusplus

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -251,13 +251,7 @@ PyObject_Init(PyObject *op, PyTypeObject *tp)
 {
     if (op == NULL)
         return PyErr_NoMemory();
-    /* Any changes should be reflected in PyObject_INIT (objimpl.h) */
-    Py_TYPE(op) = tp;
-    if (PyType_GetFlags(tp) & Py_TPFLAGS_HEAPTYPE) {
-        Py_INCREF(tp);
-    }
-    _Py_NewReference(op);
-    return op;
+    return PyObject_INIT(op, tp);
 }
 
 PyVarObject *
@@ -2205,6 +2199,29 @@ _Py_Dealloc(PyObject *op)
     _Py_INC_TPFREES(op);
 #endif
     (*dealloc)(op);
+}
+
+void
+_Py_Dealloc_GC_finalizer(void *_op, void *unused)
+{
+    PyObject *op = _Py_FROM_GC(_op);
+    assert(PyObject_IS_GC(op));
+    _Py_Dealloc_finalizer((void *)op, (void *)_op);
+}
+
+void
+_Py_Dealloc_finalizer(void *_op, void *is_gc)
+{
+    PyObject *op = (PyObject *)_op;
+    assert(is_gc == NULL ? !_Py_IS_GC(op) || _Py_IS_GC(op));
+    if (op->ob_refcnt != 0) {
+        fprintf(stderr, "object %p refcount leak (%ld)\n", op, op->ob_refcnt);
+        abort();
+    } else {
+        fprintf(stderr, "object %p not freed (refcount 0)\n", op);
+        abort();
+    }
+    _Py_Dealloc(op);
 }
 
 #ifdef __cplusplus

--- a/Objects/obmalloc.c
+++ b/Objects/obmalloc.c
@@ -1,5 +1,6 @@
 #include "Python.h"
 #include "pycore_pymem.h"
+#include "gc/gc.h"
 
 #include <stdbool.h>
 
@@ -96,7 +97,7 @@ _PyMem_RawMalloc(void *ctx, size_t size)
        To solve these problems, allocate an extra byte. */
     if (size == 0)
         size = 1;
-    return malloc(size);
+    return GC_MALLOC(size);
 }
 
 static void *
@@ -110,7 +111,7 @@ _PyMem_RawCalloc(void *ctx, size_t nelem, size_t elsize)
         nelem = 1;
         elsize = 1;
     }
-    return calloc(nelem, elsize);
+    return GC_MALLOC(nelem * elsize);
 }
 
 static void *
@@ -118,13 +119,13 @@ _PyMem_RawRealloc(void *ctx, void *ptr, size_t size)
 {
     if (size == 0)
         size = 1;
-    return realloc(ptr, size);
+    return GC_REALLOC(ptr, size);
 }
 
 static void
 _PyMem_RawFree(void *ctx, void *ptr)
 {
-    free(ptr);
+    /* GC_FREE(ptr); */ 
 }
 
 

--- a/Objects/obmalloc.c
+++ b/Objects/obmalloc.c
@@ -2123,7 +2123,9 @@ _PyMem_DebugRawFree(void *ctx, void *p)
     _PyMem_DebugCheckAddress(api->api_id, p);
     nbytes = read_size_t(q);
     nbytes += PYMEM_DEBUG_EXTRA_BYTES;
-    memset(q, DEADBYTE, nbytes);
+    // TODO(thomas@python.org): figure out alternative that works with
+    // _Py_Dealloc_finalize, probably by writing magic values to refcnt.
+    // memset(q, DEADBYTE, nbytes);
     api->alloc.free(api->alloc.ctx, q);
 }
 

--- a/Objects/obmalloc.c
+++ b/Objects/obmalloc.c
@@ -127,10 +127,10 @@ _PyMem_RawRealloc(void *ctx, void *ptr, size_t size)
     if (!GC_is_heap_ptr(ptr)) {
         abort();
     }
-    GC_REGISTER_FINALIZER(ptr, NULL, NULL, &fn, NULL);
+    GC_REGISTER_FINALIZER_IGNORE_SELF(ptr, NULL, NULL, &fn, NULL);
     ptr = GC_REALLOC(ptr, size);
     if (fn != NULL) {
-        GC_REGISTER_FINALIZER(ptr, fn, NULL, NULL, NULL);
+        GC_REGISTER_FINALIZER_IGNORE_SELF(ptr, fn, NULL, NULL, NULL);
     }
     return ptr;
 }
@@ -143,7 +143,7 @@ _PyMem_RawFree(void *ctx, void *ptr)
     if (!GC_is_heap_ptr(ptr)) {
         abort();
     }
-    GC_REGISTER_FINALIZER(ptr, NULL, NULL, NULL, NULL);
+    GC_REGISTER_FINALIZER_IGNORE_SELF(ptr, NULL, NULL, NULL, NULL);
 //    GC_FREE(ptr);
 }
 

--- a/PC/python3.def
+++ b/PC/python3.def
@@ -793,7 +793,6 @@ EXPORTS
   _Py_BuildValue_SizeT=python38._Py_BuildValue_SizeT
   _Py_CheckRecursionLimit=python38._Py_CheckRecursionLimit DATA
   _Py_CheckRecursiveCall=python38._Py_CheckRecursiveCall
-  _Py_Dealloc=python38._Py_Dealloc
   _Py_EllipsisObject=python38._Py_EllipsisObject DATA
   _Py_FalseStruct=python38._Py_FalseStruct DATA
   _Py_NoneStruct=python38._Py_NoneStruct DATA

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -2,6 +2,8 @@
 
 #include "Python.h"
 
+#include <gc/gc.h>
+
 #include "Python-ast.h"
 #undef Yield   /* undefine macro conflicting with <winbase.h> */
 #include "pycore_coreconfig.h"
@@ -83,6 +85,8 @@ _PyRuntime_Initialize(void)
         return _Py_INIT_OK();
     }
     runtime_initialized = 1;
+
+    GC_INIT();
 
     return _PyRuntimeState_Init(&_PyRuntime);
 }
@@ -534,6 +538,8 @@ pycore_create_interpreter(_PyRuntimeState *runtime,
 
     /* Create the GIL */
     PyEval_InitThreads();
+
+    GC_allow_register_threads();
 
     return _Py_INIT_OK();
 }

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -86,6 +86,7 @@ _PyRuntime_Initialize(void)
     }
     runtime_initialized = 1;
 
+    GC_set_all_interior_pointers(1);
     GC_INIT();
 
     return _PyRuntimeState_Init(&_PyRuntime);

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -1,6 +1,6 @@
-# generated automatically by aclocal 1.16.1 -*- Autoconf -*-
+# generated automatically by aclocal 1.15.1 -*- Autoconf -*-
 
-# Copyright (C) 1996-2018 Free Software Foundation, Inc.
+# Copyright (C) 1996-2017 Free Software Foundation, Inc.
 
 # This file is free software; the Free Software Foundation
 # gives unlimited permission to copy and/or distribute it,

--- a/configure
+++ b/configure
@@ -635,6 +635,7 @@ LIBPYTHON
 EXT_SUFFIX
 ALT_SOABI
 SOABI
+LIBGC
 LIBC
 LIBM
 HAVE_GETHOSTBYNAME
@@ -785,6 +786,7 @@ infodir
 docdir
 oldincludedir
 includedir
+runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -840,6 +842,7 @@ with_valgrind
 with_dtrace
 with_libm
 with_libc
+with_libgc
 enable_big_digits
 with_computed_gotos
 with_ensurepip
@@ -897,6 +900,7 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
+runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE_TARNAME}'
@@ -1149,6 +1153,15 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
+  -runstatedir | --runstatedir | --runstatedi | --runstated \
+  | --runstate | --runstat | --runsta | --runst | --runs \
+  | --run | --ru | --r)
+    ac_prev=runstatedir ;;
+  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
+  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
+  | --run=* | --ru=* | --r=*)
+    runstatedir=$ac_optarg ;;
+
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1286,7 +1299,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir
+		libdir localedir mandir runstatedir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1439,6 +1452,7 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
+  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]
@@ -1537,6 +1551,7 @@ Optional Packages:
   --with(out)-dtrace      disable/enable DTrace support
   --with-libm=STRING      math library
   --with-libc=STRING      C library
+  --with-libgc=STRING     BDW GC library
   --with(out)-computed-gotos
                           Use computed gotos in evaluation loop (enabled by
                           default on supported compilers)
@@ -11251,7 +11266,7 @@ fi
 
 if test -z "$with_pymalloc"
 then
-    with_pymalloc="yes"
+    with_pymalloc="no"
 fi
 if test "$with_pymalloc" != "no"
 then
@@ -14187,6 +14202,31 @@ fi
 else
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: default LIBC=\"$LIBC\"" >&5
 $as_echo "default LIBC=\"$LIBC\"" >&6; }
+fi
+
+
+# check for --with-libgc=...
+
+LIBGC="-lgc"
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for --with-libgc=STRING" >&5
+$as_echo_n "checking for --with-libgc=STRING... " >&6; }
+
+# Check whether --with-libgc was given.
+if test "${with_libgc+set}" = set; then :
+  withval=$with_libgc;
+if test "$withval" = no
+then LIBGC=
+     { $as_echo "$as_me:${as_lineno-$LINENO}: result: force LIBGC empty" >&5
+$as_echo "force LIBGC empty" >&6; }
+elif test "$withval" != yes
+then LIBGC=$withval
+     { $as_echo "$as_me:${as_lineno-$LINENO}: result: set LIBGC=\"$withval\"" >&5
+$as_echo "set LIBGC=\"$withval\"" >&6; }
+else as_fn_error $? "proper usage is --with-libgc=STRING" "$LINENO" 5
+fi
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: default LIBGC=\"$LIBGC\"" >&5
+$as_echo "default LIBGC=\"$LIBGC\"" >&6; }
 fi
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -3401,7 +3401,7 @@ AC_ARG_WITH(pymalloc,
 
 if test -z "$with_pymalloc"
 then
-    with_pymalloc="yes"
+    with_pymalloc="no"
 fi
 if test "$with_pymalloc" != "no"
 then
@@ -4312,6 +4312,23 @@ then LIBC=$withval
 else AC_MSG_ERROR([proper usage is --with-libc=STRING])
 fi],
 [AC_MSG_RESULT(default LIBC="$LIBC")])
+
+# check for --with-libgc=...
+AC_SUBST(LIBGC)
+LIBGC="-lgc"
+AC_MSG_CHECKING(for --with-libgc=STRING)
+AC_ARG_WITH(libgc,
+            AS_HELP_STRING([--with-libgc=STRING], [BDW GC library]),
+[
+if test "$withval" = no
+then LIBGC=
+     AC_MSG_RESULT(force LIBGC empty)
+elif test "$withval" != yes
+then LIBGC=$withval
+     AC_MSG_RESULT(set LIBGC="$withval")
+else AC_MSG_ERROR([proper usage is --with-libgc=STRING])
+fi],
+[AC_MSG_RESULT(default LIBGC="$LIBGC")])
 
 # **************************************
 # * Check for gcc x64 inline assembler *


### PR DESCRIPTION
Hackish replacement of refcounting with libgc mark-and-sweep.

(Probably) requires a libgc configured with --enable-redirect-malloc (that's what I'm using). Get libgc (BDW GC, aka Bohm GC) from https:////github.com/ivmai/bdwgc.

I configure with:
./configure --enable-sigrt-signals --enable-large-config --enable-mmap --enable-static --disable-shared --prefix=/some/path/to/bdwgc --enable-redirect-malloc

And then configure Python with:
./configure --with-libgc="/some/path/to/bdwgc/lib/libgc.a /home/twouters/python/installs/bdwgc/lib/libcord.a"

